### PR TITLE
[📝 Vite manualChunks] config 빌드 코드 스플리팅 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Build outputs
+dist
+dist-ssr
+docs

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,18 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    outDir: "docs",
+    rollupOptions: {
+      // vite의 모듈 번들러 rollup에 옵션 설정
+      output: {
+        manualChunks: (id) => {
+          if (id.indexOf("node_modules") !== -1) {
+            const module = id.split("node_modules/").pop().split("/")[0];
+            return `vendor-${module}`;
+          }
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION

# 📘 Code Spliting

- Branch: code-splitting
- Subject: [📝 Vite manualChunks] config 빌드 코드 스플리팅 설정
- Commit: chore(config): Vite build manualChunks 설정 추가 (code splitting 적용)

<br>

## 📌 Changes & Notes

### 1. Vite 빌드 출력 경로(outDir) 변경
```jsx
build: {
  outDir: "docs",
}
```
- 빌드 결과물을 `docs/` 디렉토리에 출력하도록 설정

```.gitignore
# Build outputs
dist
dist-ssr
docs
```
- GitHub Pages 배포 시 `docs/` 폴더를 그대로 활용할 수 있다. 
- 이 레포는 배포 목적이 아니므로, `.gitignore`에 `docs/`를 추가해 빌드 산출물이 깃에 포함하지 않도록 했다.


### 2. rollupOptions.manualChunks 설정
```jsx
build: {
    outDir: "docs",
    rollupOptions: {
      // vite의 모듈 번들러 rollup에 옵션 설정
      output: {
        manualChunks: (id) => {
          if (id.indexOf("node_modules") !== -1) {
            const module = id.split("node_modules/").pop().split("/")[0];
            return `vendor-${module}`;
          }
        },
      },
    },
  },
```
- 번들링 과정에서 node_modules 라이브러리들을 모듈 단위로 분리
- 예: vendor-react-js, vendor-react-dom.js 형태로 청크 생성
- 초기 로딩 시 필요한 청크만 불러와 성능 최적화

<br>

## 🎯 학습 목표 및 복습할 개념 체크 리스트

1. [x] Vite에서 빌드 시 코드 스플리팅이 어떻게 동작하는지 이해한다.
2. [x] rollupOptions.manualChunks를 활용해 의도적으로 청크를 분리할 수 있다.
3. [x] 코드 스플리팅이 초기 로딩 속도와 캐싱에 미치는 효과를 이해한다.

<br>

## 📚 Reference

- [Vite build options](https://ko.vite.dev/config/build-options.html)
- [Rollup-output.manualChunks](https://rollupjs.org/configuration-options/?utm_source=chatgpt.com#output-manualchunks)

---

> 💡 이 브랜치는 학습용이며, 개인 레포 내에서만 관리됩니다.
> 원본 레포에는 PR을 보내지 않고, 개인 히스토리용으로 정리한 브랜치입니다.